### PR TITLE
Potential fix for code scanning alert no. 17: Incomplete string escaping or encoding

### DIFF
--- a/components/CorporateEmpireMap.tsx
+++ b/components/CorporateEmpireMap.tsx
@@ -329,7 +329,7 @@ const CorporateEmpireMap: React.FC = () => {
                   className="w-3 h-3 rounded-full border border-black print:bg-white" 
                   style={{ backgroundColor: node.color }}
                 />
-                <span className="text-slate-700 print:text-black">{node.label.replace('\n', ' ')}</span>
+                <span className="text-slate-700 print:text-black">{node.label.replace(/\n/g, ' ')}</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
Potential fix for [https://github.com/Recovery-Compass/compass-outlaw/security/code-scanning/17](https://github.com/Recovery-Compass/compass-outlaw/security/code-scanning/17)

To ensure that all newline characters in `node.label` are replaced by spaces, we should use a regular expression with the global flag: `.replace(/\n/g, ' ')`. This way, every `\n` is replaced, not just the first one. This change should be made on line 332 of `components/CorporateEmpireMap.tsx` where `node.label.replace('\n', ' ')` is currently used.

No new imports are needed, and there is no need for additional helper methods unless further escaping or sanitization is required (which does not appear to be the case here). This change preserves the intent and original functionality while fixing the bug.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
